### PR TITLE
로그인(인가) 처리 구현

### DIFF
--- a/application/src/main/java/oxahex/asker/auth/filter/JwtAuthenticationFilter.java
+++ b/application/src/main/java/oxahex/asker/auth/filter/JwtAuthenticationFilter.java
@@ -30,13 +30,16 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
   private static final String LOGIN_PATH = "/api/auth/login";
 
   private final AuthenticationManager authenticationManager;
+  private final ObjectMapper objectMapper;
 
   public JwtAuthenticationFilter(
-      AuthenticationManager authenticationManager
+      AuthenticationManager authenticationManager,
+      ObjectMapper objectMapper
   ) {
     super(authenticationManager);
     setFilterProcessesUrl(LOGIN_PATH);
     this.authenticationManager = authenticationManager;
+    this.objectMapper = objectMapper;
   }
 
 
@@ -47,8 +50,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
   ) throws AuthenticationException {
 
     log.info("[{}] 로그인 시도", request.getRequestURI());
-
-    ObjectMapper objectMapper = new ObjectMapper();
 
     try {
       LoginReqDto loginReqDto =
@@ -96,12 +97,12 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     AuthUser authUser = (AuthUser) authResult.getPrincipal();
     String accessToken = JwtTokenProvider.create(authUser, JwtTokenType.ACCESS_TOKEN);
-    // TODO: Refresh Token 처리
 
     response.addHeader(JWT_HEADER_NAME, JWT_HEADER_PREFIX + accessToken);
 
     LoginResDto loginResDto = new LoginResDto(authUser.getUser());
-    ResponseUtil.success(response, HttpStatus.OK, "정상적으로 로그인 되었습니다.", loginResDto);
+
+    ResponseUtil.success(objectMapper, response, HttpStatus.OK, "정상적으로 로그인 되었습니다.", loginResDto);
   }
 
   /**
@@ -118,6 +119,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         request.getRequestURI());
 
     ResponseUtil.failure(
+        objectMapper,
         response,
         AuthError.AUTHENTICATION_FAILURE.getHttpStatus(),
         AuthError.AUTHENTICATION_FAILURE.getErrorMessage()

--- a/application/src/main/java/oxahex/asker/auth/filter/JwtAuthenticationFilter.java
+++ b/application/src/main/java/oxahex/asker/auth/filter/JwtAuthenticationFilter.java
@@ -14,8 +14,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import oxahex.asker.auth.AuthUser;
-import oxahex.asker.auth.jwt.JwtTokenProvider;
-import oxahex.asker.auth.jwt.TokenType;
+import oxahex.asker.auth.token.JwtTokenProvider;
+import oxahex.asker.auth.token.JwtTokenType;
 import oxahex.asker.dto.auth.LoginDto.LoginReqDto;
 import oxahex.asker.dto.auth.LoginDto.LoginResDto;
 import oxahex.asker.error.exception.AuthException;
@@ -88,7 +88,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         request.getRequestURI());
 
     AuthUser authUser = (AuthUser) authResult.getPrincipal();
-    String accessToken = JwtTokenProvider.create(authUser, TokenType.ACCESS_TOKEN);
+    String accessToken = JwtTokenProvider.create(authUser, JwtTokenType.ACCESS_TOKEN);
     // TODO: Refresh Token 처리
 
     response.addHeader(HEADER, accessToken);

--- a/application/src/main/java/oxahex/asker/auth/filter/JwtAuthorizationFilter.java
+++ b/application/src/main/java/oxahex/asker/auth/filter/JwtAuthorizationFilter.java
@@ -21,25 +21,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
   private static final String JWT_HEADER_NAME = "Authorization";
   private static final String JWT_HEADER_PREFIX = "Bearer ";
 
-  private static final String[] EXCLUDE_PATH = {
-      "/api/auth/join", "/api/auth/login", "/api/auth/logout", "/api/asks"
-  };
-
   public JwtAuthorizationFilter(AuthenticationManager authenticationManager) {
     super(authenticationManager);
-  }
-
-  /**
-   * JWT 유효성 검사 예외 URL 지정
-   */
-  @Override
-  protected boolean shouldNotFilter(
-      HttpServletRequest request
-  ) throws ServletException {
-
-    String path = request.getRequestURI();
-
-    return Arrays.stream(EXCLUDE_PATH).anyMatch(path::startsWith);
   }
 
   /**

--- a/application/src/main/java/oxahex/asker/auth/filter/JwtAuthorizationFilter.java
+++ b/application/src/main/java/oxahex/asker/auth/filter/JwtAuthorizationFilter.java
@@ -7,14 +7,27 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import oxahex.asker.auth.AuthUser;
+import oxahex.asker.auth.token.JwtTokenProvider;
 
 @Slf4j
-public class JwtAuthorizationFilter extends OncePerRequestFilter {
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+
+  private static final String JWT_HEADER_NAME = "Authorization";
+  private static final String JWT_HEADER_PREFIX = "Bearer ";
 
   private static final String[] EXCLUDE_PATH = {
       "/api/auth/join", "/api/auth/login", "/api/auth/logout", "/api/asks"
   };
+
+  public JwtAuthorizationFilter(AuthenticationManager authenticationManager) {
+    super(authenticationManager);
+  }
 
   /**
    * JWT 유효성 검사 예외 URL 지정
@@ -40,8 +53,41 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       FilterChain filterChain
   ) throws ServletException, IOException {
 
-    log.info("JwtFilter.doFilterInternal request={}", request.getRequestURI());
+    log.info("[{}] JWT 유효성 검사", request.getRequestURI());
+
+    // Header 유효성 검증
+    if (verifyHeader(request, response)) {
+      // 토큰이 존재함
+      String token = request.getHeader(JWT_HEADER_NAME).replace(JWT_HEADER_PREFIX, "");
+
+      log.info("[토큰이 존재함] {}", token);
+      AuthUser authUser = JwtTokenProvider.verify(token);
+
+      // 인증된 Authentication 객체
+      Authentication authentication =
+          new UsernamePasswordAuthenticationToken(
+              authUser, null, authUser.getAuthorities()
+          );
+
+      // SecurityContextHolder 저장
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
 
     filterChain.doFilter(request, response);
+  }
+
+  private boolean verifyHeader(
+      HttpServletRequest request,
+      HttpServletResponse response
+  ) {
+
+    String header = request.getHeader(JWT_HEADER_NAME);
+
+    // Header가 없거나, 시작 값이 'Bearer '가 아닌 경우
+    if (header == null || !header.startsWith(JWT_HEADER_PREFIX)) {
+      return false;
+    } else {
+      return true;
+    }
   }
 }

--- a/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
+++ b/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
@@ -64,9 +64,16 @@ public class JwtTokenProvider {
         JWT.require(Algorithm.HMAC512(JWT_TOKEN_KEY)).build().verify(token);
 
     Long id = decodedJWT.getClaim(KEY_ID).asLong();
+    String email = decodedJWT.getSubject();
     String role = decodedJWT.getClaim(KEY_ROLE).asString();
 
-    User user = User.builder().id(id).role(RoleType.valueOf(role)).build();
+    User user = User.builder()
+        .id(id)
+        .email(email)
+        .role(RoleType.valueOf(role))
+        .build();
+
+    log.info("role={}", user.getRole());
     return new AuthUser(user);
   }
 

--- a/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
+++ b/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
@@ -36,19 +36,13 @@ public class JwtTokenProvider {
     Date now = new Date(System.currentTimeMillis());
     Date expireDate = new Date(now.getTime() + tokenType.getExpireTime());
 
-    String jwtToken = JWT.create()
+    return JWT.create()
         .withSubject(authUser.getUsername())
         .withIssuedAt(now)
         .withExpiresAt(expireDate)
         .withClaim(KEY_ID, authUser.getUser().getId())
         .withClaim(KEY_ROLE, authUser.getUser().getRole().name())
         .sign(Algorithm.HMAC512(JWT_TOKEN_KEY));
-
-    if (tokenType == JwtTokenType.REFRESH_TOKEN) {
-      // TODO: Redis 저장
-    }
-
-    return jwtToken;
   }
 
   /**

--- a/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
+++ b/application/src/main/java/oxahex/asker/auth/token/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package oxahex.asker.auth.jwt;
+package oxahex.asker.auth.token;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -29,7 +29,7 @@ public class JwtTokenProvider {
    * @param tokenType 생성할 토큰 타입(ACCESS_TOKEN, REFRESH_TOKEN)
    * @return JWT Token
    */
-  public static String create(AuthUser authUser, TokenType tokenType) {
+  public static String create(AuthUser authUser, JwtTokenType tokenType) {
 
     log.info("[JWT {} 발급] email={}", tokenType.name(), authUser.getUsername());
 
@@ -44,7 +44,7 @@ public class JwtTokenProvider {
         .withClaim(KEY_ROLE, authUser.getUser().getRole().name())
         .sign(Algorithm.HMAC512(JWT_TOKEN_KEY));
 
-    if (tokenType == TokenType.REFRESH_TOKEN) {
+    if (tokenType == JwtTokenType.REFRESH_TOKEN) {
       // TODO: Redis 저장
     }
 

--- a/application/src/main/java/oxahex/asker/auth/token/JwtTokenType.java
+++ b/application/src/main/java/oxahex/asker/auth/token/JwtTokenType.java
@@ -1,11 +1,11 @@
-package oxahex.asker.auth.jwt;
+package oxahex.asker.auth.token;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum TokenType {
+public enum JwtTokenType {
 
   ACCESS_TOKEN(1000 * 60 * 60),               // 1 hour
   REFRESH_TOKEN(1000 * 60 * 60 * 24),         // 24 hour

--- a/application/src/main/java/oxahex/asker/config/RedisConfig.java
+++ b/application/src/main/java/oxahex/asker/config/RedisConfig.java
@@ -2,7 +2,14 @@ package oxahex.asker.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -13,5 +20,25 @@ public class RedisConfig {
   @Value("${spring.data.redis.port}")
   private String port;
 
+  // Redis Connection Pool
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+    conf.setHostName(this.host);
+    conf.setPort(Integer.parseInt(this.port));
+
+    return new LettuceConnectionFactory(conf);
+  }
+
+  // Redis Template으로 Redis 접근
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+    return redisTemplate;
+  }
 }
 

--- a/application/src/main/java/oxahex/asker/config/SecurityConfig.java
+++ b/application/src/main/java/oxahex/asker/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;

--- a/application/src/main/java/oxahex/asker/config/SecurityConfig.java
+++ b/application/src/main/java/oxahex/asker/config/SecurityConfig.java
@@ -29,7 +29,6 @@ import oxahex.asker.error.handler.AuthenticationExceptionHandler;
 @Slf4j
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/application/src/main/java/oxahex/asker/config/WebConfig.java
+++ b/application/src/main/java/oxahex/asker/config/WebConfig.java
@@ -1,5 +1,6 @@
 package oxahex.asker.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,13 @@ public class WebConfig {
 
     log.debug("[PasswordEncoder] Bean 등록");
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public ObjectMapper objectMapper() {
+
+    log.debug("[ObjectMapper] Bean 등록");
+    return new ObjectMapper();
   }
 }
 

--- a/application/src/main/java/oxahex/asker/error/handler/AuthenticationExceptionHandler.java
+++ b/application/src/main/java/oxahex/asker/error/handler/AuthenticationExceptionHandler.java
@@ -1,17 +1,20 @@
 package oxahex.asker.error.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 import oxahex.asker.error.type.AuthError;
 import oxahex.asker.utils.ResponseUtil;
 
 @Slf4j
-@Component
+@RequiredArgsConstructor
 public class AuthenticationExceptionHandler implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
 
   /**
    * Email, Password 로그인 실패 시 예외 처리
@@ -25,6 +28,7 @@ public class AuthenticationExceptionHandler implements AuthenticationEntryPoint 
 
     log.error("[AuthenticationExceptionHandler] 로그인 실패");
     ResponseUtil.failure(
+        objectMapper,
         response,
         AuthError.AUTHENTICATION_FAILURE.getHttpStatus(),
         AuthError.AUTHENTICATION_FAILURE.getErrorMessage()

--- a/application/src/main/java/oxahex/asker/error/handler/AuthorizationExceptionHandler.java
+++ b/application/src/main/java/oxahex/asker/error/handler/AuthorizationExceptionHandler.java
@@ -1,19 +1,22 @@
 package oxahex.asker.error.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.stereotype.Component;
 import oxahex.asker.error.type.AuthError;
 import oxahex.asker.utils.ResponseUtil;
 
 @Slf4j
-@Component
+@RequiredArgsConstructor
 public class AuthorizationExceptionHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
 
   @Override
   public void handle(
@@ -24,6 +27,7 @@ public class AuthorizationExceptionHandler implements AccessDeniedHandler {
 
     log.error("[AuthorizationExceptionHandler] 권한 오류");
     ResponseUtil.failure(
+        objectMapper,
         response,
         AuthError.ACCESS_DENIED.getHttpStatus(),
         AuthError.ACCESS_DENIED.getErrorMessage()

--- a/application/src/main/java/oxahex/asker/utils/ResponseUtil.java
+++ b/application/src/main/java/oxahex/asker/utils/ResponseUtil.java
@@ -11,6 +11,7 @@ import oxahex.asker.dto.ResponseDto;
 public class ResponseUtil {
 
   public static void success(
+      ObjectMapper objectMapper,
       HttpServletResponse response,
       HttpStatus status,
       String message,
@@ -20,7 +21,6 @@ public class ResponseUtil {
 
       ResponseDto<?> responseDto = new ResponseDto<>(status.value(), message, dto);
 
-      ObjectMapper objectMapper = new ObjectMapper();
       String responseBody = objectMapper.writeValueAsString(responseDto);
 
       response.setStatus(status.value());
@@ -36,6 +36,7 @@ public class ResponseUtil {
 
   // TODO: Error Type Enum을 인자로 받도록 리팩토링 하면 어떨지?
   public static void failure(
+      ObjectMapper objectMapper,
       HttpServletResponse response,
       HttpStatus status,
       String message
@@ -44,7 +45,6 @@ public class ResponseUtil {
 
       ResponseDto<?> responseDto = new ResponseDto<>(status.value(), message, null);
 
-      ObjectMapper objectMapper = new ObjectMapper();
       String responseBody = objectMapper.writeValueAsString(responseDto);
 
       response.setStatus(status.value());

--- a/application/src/test/java/oxahex/asker/auth/filter/JwtAuthenticationFilterTest.java
+++ b/application/src/test/java/oxahex/asker/auth/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,92 @@
+package oxahex.asker.auth.filter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import oxahex.asker.domain.user.UserRepository;
+import oxahex.asker.dto.auth.LoginDto.LoginReqDto;
+import oxahex.asker.mock.MockUser;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@Transactional
+class JwtAuthenticationFilterTest extends MockUser {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    // 기존 유저 생성
+    userRepository.save(newUser("test", "1234567890"));
+  }
+
+  @Test
+  @DisplayName("인증 성공 - Email, Password 일치, 가입된 회원의 경우 로그인에 성공하고 Access Token이 발급된다.")
+  public void successfulAuthentication() throws Exception {
+
+    // given
+    LoginReqDto loginResDto = new LoginReqDto();
+    loginResDto.setEmail("test@gmail.com");
+    loginResDto.setPassword("1234567890");
+
+    String requestBody = objectMapper.writeValueAsString(loginResDto);
+
+    // when
+    ResultActions resultActions =
+        mockMvc.perform(get("/api/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+    String accessToken = resultActions.andReturn().getResponse().getHeader("Authorization");
+
+    // then
+    resultActions.andExpect(status().isOk());
+    resultActions.andExpect(jsonPath("$.data.name").value("test"));
+    resultActions.andExpect(jsonPath("$.data.email").value("test@gmail.com"));
+    resultActions.andExpect(jsonPath("$.data.role").value("USER"));
+    Assertions.assertNotNull(accessToken);
+    Assertions.assertTrue(accessToken.startsWith("Bearer "));
+  }
+
+  @Test
+  @DisplayName("인증 실패 - Password가 맞지 않는 경유 인증에 실패하고 401 에러가 반환된다.")
+  public void unsuccessfulAuthentication() throws Exception {
+
+    // given
+    LoginReqDto loginResDto = new LoginReqDto();
+    loginResDto.setEmail("test@gmail.com");
+    loginResDto.setPassword("wrong password");
+
+    String requestBody = objectMapper.writeValueAsString(loginResDto);
+
+    // when
+    ResultActions resultActions =
+        mockMvc.perform(get("/api/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+    // then
+    resultActions.andExpect(status().isUnauthorized());
+  }
+}

--- a/application/src/test/java/oxahex/asker/auth/filter/JwtAuthenticationFilterTest.java
+++ b/application/src/test/java/oxahex/asker/auth/filter/JwtAuthenticationFilterTest.java
@@ -43,7 +43,7 @@ class JwtAuthenticationFilterTest extends MockUser {
 
   @Test
   @DisplayName("인증 성공 - Email, Password 일치, 가입된 회원의 경우 로그인에 성공하고 Access Token이 발급된다.")
-  public void successfulAuthentication() throws Exception {
+  public void authenticate_success() throws Exception {
 
     // given
     LoginReqDto loginResDto = new LoginReqDto();
@@ -71,7 +71,7 @@ class JwtAuthenticationFilterTest extends MockUser {
 
   @Test
   @DisplayName("인증 실패 - Password가 맞지 않는 경유 인증에 실패하고 401 에러가 반환된다.")
-  public void unsuccessfulAuthentication() throws Exception {
+  public void authenticate_failure() throws Exception {
 
     // given
     LoginReqDto loginResDto = new LoginReqDto();

--- a/application/src/test/java/oxahex/asker/auth/filter/JwtAuthorizationFilterTest.java
+++ b/application/src/test/java/oxahex/asker/auth/filter/JwtAuthorizationFilterTest.java
@@ -1,0 +1,58 @@
+package oxahex.asker.auth.filter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import oxahex.asker.auth.AuthUser;
+import oxahex.asker.auth.token.JwtTokenProvider;
+import oxahex.asker.auth.token.JwtTokenType;
+import oxahex.asker.domain.user.User;
+import oxahex.asker.mock.MockUser;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+class JwtAuthorizationFilterTest extends MockUser {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("인가 성공 - 유효한 Access Token으로 인가 필요한 URL 요청 시 인가 필터를 통과한다.")
+  public void authorize_success() throws Exception {
+
+    // given
+    User user = mockUser(1L, "test", "1234567890");
+    AuthUser authUser = new AuthUser(user);
+    String accessToken = JwtTokenProvider.create(authUser, JwtTokenType.ACCESS_TOKEN);
+
+    // when: 없는 주소
+    ResultActions resultActions =
+        mockMvc.perform(get("/api/users/test")
+            .header("Authorization", "Bearer " + accessToken));
+
+    // then
+    resultActions.andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("인가 실패 - Access Token 없이 인가 필요한 URL 요청 시 403을 반환한다.")
+  public void authorize_failure() throws Exception {
+
+    // given
+
+    // when: 없는 주소로 Access Token 없이 요청
+    ResultActions resultActions = mockMvc.perform(get("/api/users/test"));
+
+    // then
+    resultActions.andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
- ObjectMapper Bean으로 관리
- 인가 필터 내 인가 처리 예외 URL 제거(Security Config 내 설정으로 관리)
- 인증(로그인 `POST /api/auth/login`) #11 
    - Email, Password 인증
      - 성공 시 JWT Access Token 발급
      - 실패 시 401(인증 실패) 반환
- 인가
  - Access Token 유효성 검사 및 권한 확인
  - 유효성 검사 통과 시 Controller 진입
  - 유효성 검사 실패 시 Controller 진입하지 않고 403(권한 없음)에러 반환 

### 테스트

- [x] 테스트 코드
- [x] API 테스트 