### PR TITLE
알림 생성, 조회, 읽음 처리 구현

### DIFF
--- a/application/src/main/java/oxahex/asker/config/WebConfig.java
+++ b/application/src/main/java/oxahex/asker/config/WebConfig.java
@@ -1,6 +1,7 @@
 package oxahex.asker.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +14,7 @@ import oxahex.asker.domain.condition.converter.SortTypeConverter;
 @Slf4j
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-  
+
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new SortTypeConverter());
@@ -30,7 +31,9 @@ public class WebConfig implements WebMvcConfigurer {
   public ObjectMapper objectMapper() {
 
     log.debug("[ObjectMapper] Bean 등록");
-    return new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    return objectMapper;
   }
 
 }

--- a/application/src/main/java/oxahex/asker/notification/NotificationController.java
+++ b/application/src/main/java/oxahex/asker/notification/NotificationController.java
@@ -9,11 +9,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import oxahex.asker.auth.AuthUser;
 import oxahex.asker.common.ResponseDto;
+import oxahex.asker.notification.dto.NotificationDto.NotificationInfoDto;
 import oxahex.asker.notification.dto.NotificationDto.NotificationListDto;
 
 @Slf4j
@@ -47,5 +49,24 @@ public class NotificationController {
         notificationService.getNotifications(authUser, pageRequest);
 
     return ResponseEntity.ok(new ResponseDto<>(200, "", notifications));
+  }
+
+  /**
+   * 특정 알림 확인(상세 보기)
+   *
+   * @param authUser 로그인 유저
+   * @return 알림 상세 정보 반환
+   */
+  @GetMapping("/{notificationId}")
+  public ResponseEntity<?> readNotification(
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal AuthUser authUser
+  ) {
+
+    log.info("[유저 알림 읽기] userEmail={}", authUser.getUsername());
+    NotificationInfoDto notification = notificationService.getNotification(authUser,
+        notificationId);
+
+    return ResponseEntity.ok(new ResponseDto<>(200, "", notification));
   }
 }

--- a/application/src/main/java/oxahex/asker/notification/NotificationController.java
+++ b/application/src/main/java/oxahex/asker/notification/NotificationController.java
@@ -1,0 +1,51 @@
+package oxahex.asker.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import oxahex.asker.auth.AuthUser;
+import oxahex.asker.common.ResponseDto;
+import oxahex.asker.notification.dto.NotificationDto.NotificationListDto;
+
+@Slf4j
+@RestController
+@PreAuthorize("hasAuthority('USER')")
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  /**
+   * 읽지 않은 모든 알림 목록 조회
+   *
+   * @param authUser 로그인 유저
+   * @return 읽지 않은 알림 내역
+   */
+  @GetMapping
+  public ResponseEntity<ResponseDto<NotificationListDto>> getNotifications(
+      @AuthenticationPrincipal AuthUser authUser,
+      @RequestParam(defaultValue = "0") Integer page,
+      @RequestParam(defaultValue = "10") Integer size
+  ) {
+
+    log.info("[유저 알림 조회] userEmail={}", authUser.getUsername());
+
+    PageRequest pageRequest = PageRequest.of(page, size,
+        Sort.by(Direction.DESC, "createdDateTime"));
+
+    NotificationListDto notifications =
+        notificationService.getNotifications(authUser, pageRequest);
+
+    return ResponseEntity.ok(new ResponseDto<>(200, "", notifications));
+  }
+}

--- a/application/src/main/java/oxahex/asker/notification/NotificationService.java
+++ b/application/src/main/java/oxahex/asker/notification/NotificationService.java
@@ -1,0 +1,40 @@
+package oxahex.asker.notification;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import oxahex.asker.auth.AuthUser;
+import oxahex.asker.domain.notification.Notification;
+import oxahex.asker.domain.notification.NotificationDomainService;
+import oxahex.asker.domain.user.User;
+import oxahex.asker.notification.dto.NotificationDto;
+import oxahex.asker.notification.dto.NotificationDto.NotificationListDto;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationDomainService notificationDomainService;
+
+  /**
+   * 읽지 않은 알림 목록 조회
+   *
+   * @param authUser 로그인 유저
+   * @return 읽지 않은 알림 목록 DTO
+   */
+  public NotificationListDto getNotifications(AuthUser authUser, PageRequest pageRequest) {
+
+    User user = authUser.getUser();
+
+    Slice<Notification> notifications =
+        notificationDomainService.findNotifications(user, pageRequest);
+
+    return NotificationDto.fromEntityToNotificationList(user, notifications);
+  }
+}

--- a/application/src/main/java/oxahex/asker/notification/NotificationService.java
+++ b/application/src/main/java/oxahex/asker/notification/NotificationService.java
@@ -1,6 +1,5 @@
 package oxahex.asker.notification;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -11,8 +10,11 @@ import oxahex.asker.auth.AuthUser;
 import oxahex.asker.domain.notification.Notification;
 import oxahex.asker.domain.notification.NotificationDomainService;
 import oxahex.asker.domain.user.User;
+import oxahex.asker.domain.user.UserDomainService;
 import oxahex.asker.notification.dto.NotificationDto;
+import oxahex.asker.notification.dto.NotificationDto.NotificationInfoDto;
 import oxahex.asker.notification.dto.NotificationDto.NotificationListDto;
+import oxahex.asker.utils.ValidUtil;
 
 @Slf4j
 @Service
@@ -21,6 +23,7 @@ import oxahex.asker.notification.dto.NotificationDto.NotificationListDto;
 public class NotificationService {
 
   private final NotificationDomainService notificationDomainService;
+  private final UserDomainService userDomainService;
 
   /**
    * 읽지 않은 알림 목록 조회
@@ -36,5 +39,21 @@ public class NotificationService {
         notificationDomainService.findNotifications(user, pageRequest);
 
     return NotificationDto.fromEntityToNotificationList(user, notifications);
+  }
+
+  @Transactional
+  public NotificationInfoDto getNotification(AuthUser authUser, Long notificationId) {
+
+    Notification notification = notificationDomainService.findNotification(notificationId);
+
+    // 본인의 알림인지 검증
+    ValidUtil.validateUser(authUser, notification.getReceiveUser().getId());
+
+    // 읽지 않은 알림인 경우 읽음 처리
+    if (notification.getReadDateTime() == null) {
+      notification.read();
+    }
+
+    return NotificationDto.fromEntityToNotificationInfo(notification);
   }
 }

--- a/application/src/main/java/oxahex/asker/notification/dto/NotificationDto.java
+++ b/application/src/main/java/oxahex/asker/notification/dto/NotificationDto.java
@@ -1,0 +1,59 @@
+package oxahex.asker.notification.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+import oxahex.asker.auth.dto.UserDto;
+import oxahex.asker.auth.dto.UserDto.UserInfoDto;
+import oxahex.asker.dispatch.dto.AskDto;
+import oxahex.asker.dispatch.dto.AskDto.AskInfoDto;
+import oxahex.asker.dispatch.dto.AskDto.AskListDto;
+import oxahex.asker.domain.ask.Ask;
+import oxahex.asker.domain.notification.Notification;
+import oxahex.asker.domain.notification.NotificationFrontMatter;
+import oxahex.asker.domain.user.User;
+
+public class NotificationDto {
+
+  @Getter
+  @Setter
+  public static class NotificationInfoDto {
+
+    private Long id;
+    private NotificationFrontMatter frontMatter;
+    private LocalDateTime createdDate;
+  }
+
+  public static NotificationInfoDto fromEntityToNotificationInfo(Notification notification) {
+
+    NotificationInfoDto notificationInfo = new NotificationInfoDto();
+    notificationInfo.setId(notification.getId());
+    notificationInfo.setFrontMatter(notification.getFrontMatter());
+    notificationInfo.setCreatedDate(notification.getCreatedDateTime());
+
+    return notificationInfo;
+  }
+
+  @Getter
+  @Setter
+  public static class NotificationListDto {
+
+    private UserInfoDto userInfo;
+    private Slice<NotificationInfoDto> notifications;
+  }
+
+  public static NotificationListDto fromEntityToNotificationList(
+      User user,
+      Slice<Notification> notifications
+  ) {
+
+    NotificationListDto notificationList = new NotificationListDto();
+    notificationList.setUserInfo(UserDto.fromEntityToUserInfo(user));
+    notificationList.setNotifications(
+        notifications.map(NotificationDto::fromEntityToNotificationInfo));
+
+    return notificationList;
+  }
+}

--- a/application/src/main/java/oxahex/asker/notification/dto/NotificationDto.java
+++ b/application/src/main/java/oxahex/asker/notification/dto/NotificationDto.java
@@ -13,6 +13,7 @@ import oxahex.asker.dispatch.dto.AskDto.AskListDto;
 import oxahex.asker.domain.ask.Ask;
 import oxahex.asker.domain.notification.Notification;
 import oxahex.asker.domain.notification.NotificationFrontMatter;
+import oxahex.asker.domain.notification.NotificationType;
 import oxahex.asker.domain.user.User;
 
 public class NotificationDto {
@@ -23,6 +24,8 @@ public class NotificationDto {
 
     private Long id;
     private NotificationFrontMatter frontMatter;
+    private NotificationType notificationType;
+    private LocalDateTime readDate;
     private LocalDateTime createdDate;
   }
 
@@ -31,10 +34,13 @@ public class NotificationDto {
     NotificationInfoDto notificationInfo = new NotificationInfoDto();
     notificationInfo.setId(notification.getId());
     notificationInfo.setFrontMatter(notification.getFrontMatter());
+    notificationInfo.setNotificationType(notification.getNotificationType());
+    notificationInfo.setReadDate(notification.getReadDateTime());
     notificationInfo.setCreatedDate(notification.getCreatedDateTime());
 
     return notificationInfo;
   }
+
 
   @Getter
   @Setter

--- a/domain/src/main/java/oxahex/asker/domain/ask/AskDomainService.java
+++ b/domain/src/main/java/oxahex/asker/domain/ask/AskDomainService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import oxahex.asker.domain.error.exception.DispatchException;
 import oxahex.asker.domain.error.type.DispatchError;
+import oxahex.asker.domain.notification.NotificationRepository;
 import oxahex.asker.domain.user.User;
 
 @Slf4j

--- a/domain/src/main/java/oxahex/asker/domain/dispatch/Dispatch.java
+++ b/domain/src/main/java/oxahex/asker/domain/dispatch/Dispatch.java
@@ -29,7 +29,7 @@ public class Dispatch {
   private Long id;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "ask_id")
+  @JoinColumn(name = "ask_id", nullable = false)
   private Ask ask;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/domain/src/main/java/oxahex/asker/domain/error/exception/NotificationException.java
+++ b/domain/src/main/java/oxahex/asker/domain/error/exception/NotificationException.java
@@ -1,0 +1,14 @@
+package oxahex.asker.domain.error.exception;
+
+import oxahex.asker.domain.error.type.NotificationError;
+
+public class NotificationException extends RuntimeException {
+  
+  int statusCode;
+  String errorMessage;
+
+  public NotificationException(NotificationError notificationError) {
+    this.statusCode = notificationError.getStatusCode();
+    this.errorMessage = notificationError.getErrorMessage();
+  }
+}

--- a/domain/src/main/java/oxahex/asker/domain/error/type/NotificationError.java
+++ b/domain/src/main/java/oxahex/asker/domain/error/type/NotificationError.java
@@ -1,0 +1,14 @@
+package oxahex.asker.domain.error.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationError {
+
+  NOTIFICATION_NOT_FOUND(404, "존재하지 않는 알림입니다.");
+
+  private final int statusCode;
+  private final String errorMessage;
+}

--- a/domain/src/main/java/oxahex/asker/domain/notification/Notification.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/Notification.java
@@ -73,4 +73,8 @@ public class Notification {
         .originUserId(originUserId)
         .excerpt(excerpt).build();
   }
+
+  public void read() {
+    this.readDateTime = LocalDateTime.now();
+  }
 }

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
@@ -1,13 +1,14 @@
 package oxahex.asker.domain.notification;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ObjectUtils;
 import oxahex.asker.domain.answer.Answer;
 import oxahex.asker.domain.ask.Ask;
-import oxahex.asker.domain.dispatch.Dispatch;
 import oxahex.asker.domain.user.User;
 
 @Slf4j
@@ -54,6 +55,11 @@ public class NotificationDomainService {
         .build();
 
     notificationRepository.save(notification);
+  }
+
+  public Slice<Notification> findNotifications(User user, PageRequest pageRequest) {
+
+    return notificationRepository.findAllUnReadNotification(user, pageRequest);
   }
 
 }

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
@@ -1,6 +1,5 @@
 package oxahex.asker.domain.notification;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -9,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import oxahex.asker.domain.answer.Answer;
 import oxahex.asker.domain.ask.Ask;
+import oxahex.asker.domain.error.exception.NotificationException;
+import oxahex.asker.domain.error.type.NotificationError;
 import oxahex.asker.domain.user.User;
 
 @Slf4j
@@ -62,4 +63,15 @@ public class NotificationDomainService {
     return notificationRepository.findAllUnReadNotification(user, pageRequest);
   }
 
+  /**
+   * 알림 상세 조회
+   *
+   * @param notificationId 조회하려는 알림 ID
+   * @return 해당 알림 데이터
+   */
+  public Notification findNotification(Long notificationId) {
+
+    return notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new NotificationException(NotificationError.NOTIFICATION_NOT_FOUND));
+  }
 }

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
@@ -50,7 +50,7 @@ public class NotificationDomainService {
         .notificationType(NotificationType.ANSWER)
         .originId(answer.getId())
         .originUserId(answer.getAnswerUser().getId())
-        .excerpt(answer.getContents().substring(0, 16))
+        .excerpt(answer.getContents().substring(0, 10).trim())
         .build();
 
     notificationRepository.save(notification);

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationDomainService.java
@@ -1,0 +1,59 @@
+package oxahex.asker.domain.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
+import oxahex.asker.domain.answer.Answer;
+import oxahex.asker.domain.ask.Ask;
+import oxahex.asker.domain.dispatch.Dispatch;
+import oxahex.asker.domain.user.User;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationDomainService {
+
+  private final NotificationRepository notificationRepository;
+
+  @Transactional
+  public void createNotification(
+      User receiveUser,
+      Ask ask
+  ) {
+
+    log.info("[질문 생성 시 알림 저장]");
+
+    Notification notification = Notification.builder()
+        .receiveUser(receiveUser)
+        .notificationType(NotificationType.ASK)
+        .originId(ask.getId())
+        .originUserId(ask.getAskUser() == null ? null : ask.getAskUser().getId())
+        .excerpt(ask.getContents().substring(0, 10).trim())
+        .build();
+
+    notificationRepository.save(notification);
+  }
+
+  @Transactional
+  public void createNotification(
+      User receiveUser,
+      Answer answer
+  ) {
+
+    log.info("[답변 생성 시 알림 저장]");
+
+    Notification notification = Notification.builder()
+        .receiveUser(receiveUser)
+        .notificationType(NotificationType.ANSWER)
+        .originId(answer.getId())
+        .originUserId(answer.getAnswerUser().getId())
+        .excerpt(answer.getContents().substring(0, 16))
+        .build();
+
+    notificationRepository.save(notification);
+  }
+
+}

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
@@ -1,0 +1,9 @@
+package oxahex.asker.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
@@ -1,9 +1,17 @@
 package oxahex.asker.domain.notification;
 
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import oxahex.asker.domain.user.User;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+  @Query("select n from Notification as n where n.receiveUser = :user and n.readDateTime = null")
+  Slice<Notification> findAllUnReadNotification(@Param("user") User user, PageRequest pageRequest);
 }

--- a/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
+++ b/domain/src/main/java/oxahex/asker/domain/notification/NotificationRepository.java
@@ -1,6 +1,7 @@
 package oxahex.asker.domain.notification;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**

- 답변 생성 또는 질문이 들어왔을 때 알림 테이블에 데이터 저정
- 알림 목록 조회 기능 구현 
- 알림 한 건 조회 기능 구현
  - 한 건 조회 시 read_date 컬럼에 현재 시각 저장 처리

Redis Pub/Sub 구현 전에 우선 
로그인 시에 알림이 새로 들어온 것이 있는지 확인하도록 구현하려면,
새 알림이 있는지 판단하려면, 기존 알림에 대한 정보가 있어야 할 것 같은데
이 경우 프론트에서 마지막 알람 정보(가장 최신 알람의 생성 시각)를 주도록 하고,
백엔드에서 그 데이터를 기반으로 업데이트 된 알림이 있는지 확인해서 새 알람 존재 여부를 내려주는 방법 정도가 생각나는데...
혹시 더 좋은 방법이 있을지요...? 

### 테스트

- [ ] 테스트 코드
- [ ] API 테스트 